### PR TITLE
Remove target_dir that is no longer used in download module

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,10 +1,8 @@
 # ex: syntax=puppet si sw=2 ts=2 et
 class terraform (
   $version,
-  $target_dir = '/usr/local/bin',
 ) {
   hashicorp::download { 'terraform':
     version    => $version,
-    target_dir => $target_dir,
   }
 }


### PR DESCRIPTION
This is no longer necessary for the download module since it's no longer defined. This fixes the (currently) broken module.